### PR TITLE
Add CI workflow for lint and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,4 @@
+---
 name: Test
 
 on:
@@ -18,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20
+          node-version-file: "package.json"
           cache: yarn
           cache-dependency-path: yarn.lock
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Lint and test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 20
+          cache: yarn
+          cache-dependency-path: yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --ignore-scripts
+
+      - name: Run lint and tests
+        run: yarn test

--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
   },
   "author": "Ivo Meißner",
   "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  },
   "devDependencies": {
     "@types/assert": "1.5.11",
     "@types/chai": "4.3.20",

--- a/src/QueryComplexity.ts
+++ b/src/QueryComplexity.ts
@@ -310,23 +310,23 @@ export default class QueryComplexity {
 
             switch (childNode.kind) {
               case Kind.FIELD: {
-                let field = null
+                let field = null;
 
                 switch (childNode.name.value) {
                   case SchemaMetaFieldDef.name:
-                    field = SchemaMetaFieldDef
+                    field = SchemaMetaFieldDef;
                     break;
                   case TypeMetaFieldDef.name:
-                    field = TypeMetaFieldDef
+                    field = TypeMetaFieldDef;
                     break;
                   case TypeNameMetaFieldDef.name:
-                    field = TypeNameMetaFieldDef
+                    field = TypeNameMetaFieldDef;
                     break;
                   default:
                     field = fields[childNode.name.value];
                     break;
                 }
-                
+
                 // Invalid field, should be caught by other validation rules
                 if (!field) {
                   break;


### PR DESCRIPTION
## Summary
- Add `.github/workflows/test.yml` to run `yarn test` (lint + CJS/ESM Mocha suite) on pushes and PRs to `master`.
- Fix Prettier drift in `QueryComplexity.ts` so lint passes on current `master`.

## Test plan
- [x] CI workflow runs on this PR
- [x] `yarn test` passes (74 tests in CJS and ESM)


Made with [Cursor](https://cursor.com)